### PR TITLE
Remove Steam autostart file

### DIFF
--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -71,5 +71,8 @@ run_script "/ctx/install-alsa-scarlett-gui.sh"
 
 
 
+# Remove autostart files
+rm -f /etc/skel/.config/autostart/steam.desktop
+
 # Clean package manager cache
 dnf5 clean all


### PR DESCRIPTION
Only applies to new users, not for existing users rebasing.