### PR TITLE
Add nct6775 kernel module for ASUS ROG Strix B650E-F Gaming Wifi

### DIFF
--- a/build_files/install-copr-pkgs.sh
+++ b/build_files/install-copr-pkgs.sh
@@ -16,5 +16,12 @@ dnf5 -y install \
 # Enable daemon
 systemctl enable coolercontrold
 
+# Load the nct6775 kernel module for ASUS ROG Strix B650E-F Gaming Wifi
+# https://github.com/lm-sensors/lm-sensors/issues/416#issuecomment-2359409670
+# sudo modprobe nct6775
+
+# Load the module after every reboot
+echo "nct6775" | tee /etc/modules-load.d/nct6775.conf
+
 # Disable COPR repo
 dnf5 -y copr disable codifryed/CoolerControl


### PR DESCRIPTION
Needed to control fan headers in CoolerControl.