### PR TITLE
Just recipes for kargs

### DIFF
--- a/build_files/install-copr-pkgs.sh
+++ b/build_files/install-copr-pkgs.sh
@@ -24,7 +24,7 @@ systemctl enable coolercontrold
 mkdir -p /etc/modules-load.d
 echo "nct6775" | tee /etc/modules-load.d/nct6775.conf
 
-# Add kernel argument to enable full AMD GPU functionality
+# Add kernel argument to enable all features for AMD GPUs
 mkdir -p /usr/lib/bootc/kargs.d
 cat <<EOF > /usr/lib/bootc/kargs.d/99-amdgpu.toml
 kargs = ["amdgpu.ppfeaturemask=0xffffffff"]

--- a/build_files/install-copr-pkgs.sh
+++ b/build_files/install-copr-pkgs.sh
@@ -20,18 +20,21 @@ systemctl enable coolercontrold
 # https://github.com/lm-sensors/lm-sensors/issues/416#issuecomment-2359409670
 # sudo modprobe nct6775
 
-# Load the module after every reboot
+# Load the nct6775 kernel module after every reboot
 mkdir -p /etc/modules-load.d
 echo "nct6775" | tee /etc/modules-load.d/nct6775.conf
 
-# Enable AMD GPU fan control
+# Add kernel argument to enable full AMD GPU functionality
 mkdir -p /usr/lib/bootc/kargs.d
 cat <<EOF > /usr/lib/bootc/kargs.d/99-amdgpu.toml
 kargs = ["amdgpu.ppfeaturemask=0xffffffff"]
 EOF
 
-# If above doesn't work, run this manually on live system
+# If above doesn't work, run this manually on live system to add karg
 # rpm-ostree kargs --append-if-missing=amdgpu.ppfeaturemask=0xffffffff
+
+# Revert karg
+# rpm-ostree kargs --delete=amdgpu.ppfeaturemask=0xffffffff
 
 # Disable COPR repo
 dnf5 -y copr disable codifryed/CoolerControl

--- a/system_files/usr/share/wepos/just/coolercontrol.just
+++ b/system_files/usr/share/wepos/just/coolercontrol.just
@@ -21,7 +21,7 @@ delete-karg:
 	# Variables
 	command="rpm-ostree kargs --delete=amdgpu.ppfeaturemask=0xffffffff"
 	
-	# Add karg
+	# Remove karg
 	echo "Running command: $command"
 	eval $command
 	echo 'Complete, please reboot to apply changes.'

--- a/system_files/usr/share/wepos/just/coolercontrol.just
+++ b/system_files/usr/share/wepos/just/coolercontrol.just
@@ -1,0 +1,27 @@
+# Add kernel argument to enable all features for AMD GPUs
+[group('CoolerControl')]
+append-karg:
+	#!/usr/bin/env bash
+	set -euo pipefail
+	
+	# Variables
+	command="rpm-ostree kargs --append-if-missing=amdgpu.ppfeaturemask=0xffffffff"
+	
+	# Add karg
+	echo "Running command: $command"
+	eval $command
+	echo 'Complete, please reboot to apply changes.'
+
+# Remove the kernel argument
+[group('CoolerControl')]
+delete-karg:
+	#!/usr/bin/env bash
+	set -euo pipefail
+	
+	# Variables
+	command="rpm-ostree kargs --delete=amdgpu.ppfeaturemask=0xffffffff"
+	
+	# Add karg
+	echo "Running command: $command"
+	eval $command
+	echo 'Complete, please reboot to apply changes.'

--- a/system_files/usr/share/wepos/just/theme.just
+++ b/system_files/usr/share/wepos/just/theme.just
@@ -1,5 +1,5 @@
 # Install WepOS Global Theme
-[group('Install')]
+[group('Theme')]
 install-global-theme:
 	#!/usr/bin/env bash
 	set -euo pipefail
@@ -18,7 +18,7 @@ install-global-theme:
 	fi
 
 # Install dynamic wallpapers
-[group('Install')]
+[group('Theme')]
 install-dynamic-wallpapers:
 	#!/usr/bin/env bash
 	set -euo pipefail
@@ -37,5 +37,5 @@ install-dynamic-wallpapers:
 	fi
 
 # Setup global theme and wallpapers
-[group('Install')]
+[group('Theme')]
 setup-theme: install-global-theme install-dynamic-wallpapers

--- a/system_files/usr/share/wepos/justfile
+++ b/system_files/usr/share/wepos/justfile
@@ -5,6 +5,7 @@ _default:
 	@just --list
 
 # Imports
+import "/usr/share/wepos/just/coolercontrol.just"
 import "/usr/share/wepos/just/keyboard-layouts.just"
 import "/usr/share/wepos/just/nerd-fonts.just"
 import "/usr/share/wepos/just/starship.just"


### PR DESCRIPTION
Adds just recipes to add or remove karg for enabling all features for AMD GPUs in CoolerControl.

Also clean up some other stuff.