### PR TITLE
Containerfile: ostree container commit is not needed (#137)

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -26,8 +26,7 @@ RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=cache,dst=/var/cache \
     --mount=type=cache,dst=/var/log \
     --mount=type=tmpfs,dst=/tmp \
-    /ctx/build.sh && \
-    ostree container commit
+    /ctx/build.sh
     
 ### LINTING
 ## Verify final image and contents are correct.


### PR DESCRIPTION
ostree container commit is not needed anymore when using bootc container lint.